### PR TITLE
Update exports logic to set module.exports

### DIFF
--- a/pokersolver.js
+++ b/pokersolver.js
@@ -1847,11 +1847,12 @@
     global.OnePair = OnePair;
     global.HighCard = HighCard;
     global.PaiGowPokerHelper = PaiGowPokerHelper;
+    return global;
   }
 
   // Export the classes for node.js use.
   if (typeof exports !== 'undefined') {
-    exportToGlobal(exports);
+    module.exports = exportToGlobal(exports);
   }
 
   // Add the classes to the window for browser use.


### PR DESCRIPTION
Some IDEs (IntelliJ to be specific) do not recognize "setting exports inside a function" logic, updating to use module.exports fixes this issue.